### PR TITLE
Add support for custom IRateLimiter to PoliteWebCrawler

### DIFF
--- a/Abot/Crawler/PoliteWebCrawler.cs
+++ b/Abot/Crawler/PoliteWebCrawler.cs
@@ -19,6 +19,8 @@ namespace Abot.Crawler
         protected IRobotsDotTextFinder _robotsDotTextFinder;
         protected IRobotsDotText _robotsDotText;
 
+        public IRateLimiter RateLimiter { get; set; }
+
         public PoliteWebCrawler()
             : this(null, null, null, null, null, null, null, null, null)
         {
@@ -82,6 +84,9 @@ namespace Abot.Crawler
 
             if (robotsDotTextCrawlDelayInSecs > 0 || _crawlContext.CrawlConfiguration.MinCrawlDelayPerDomainMilliSeconds > 0)
                 PageCrawlStarting += (s, e) => _domainRateLimiter.RateLimit(e.PageToCrawl.Uri);
+
+            if (RateLimiter != null)
+                PageCrawlStarting += (s, e) => RateLimiter.WaitToProceed();
 
             return base.Crawl(uri, cancellationTokenSource);
         }


### PR DESCRIPTION
Provide a way to inject a custom IRateLimiter to the PoliteWebCrawler, that will allow to extend the limits in many different ways:
* Different RateLimiters depending on a schedule
* Pause completely the crawl based on some logic (it could be lock files, it could be schedule, etc).