### PR TITLE
Add canonical to links found in a page

### DIFF
--- a/Abot/Core/HapHyperLinkParser.cs
+++ b/Abot/Core/HapHyperLinkParser.cs
@@ -42,9 +42,11 @@ namespace Abot.Core
 
             HtmlNodeCollection aTags = crawledPage.HtmlDocument.DocumentNode.SelectNodes("//a[@href]");
             HtmlNodeCollection areaTags = crawledPage.HtmlDocument.DocumentNode.SelectNodes("//area[@href]");
+            HtmlNodeCollection canonicals = crawledPage.HtmlDocument.DocumentNode.SelectNodes("//link[@rel='canonical'][@href]");
 
             hrefValues.AddRange(GetLinks(aTags));
             hrefValues.AddRange(GetLinks(areaTags));
+            hrefValues.AddRange(GetLinks(canonicals));
 
             return hrefValues;
         }


### PR DESCRIPTION
This change allows to add the canonical found on pages to the list of links found. Then the canonical will be enqueued (if needed). 