### PR TITLE
SSL validation parameter and Retry-After headers support

### DIFF
--- a/Abot.Tests.Integration/App.config
+++ b/Abot.Tests.Integration/App.config
@@ -63,6 +63,7 @@
       isHttpRequestAutoRedirectsEnabled="true" 
       isHttpRequestAutomaticDecompressionEnabled="false" 
       isSendingCookiesEnabled="false" 
+      isSslCertificateValidationEnabled="false"
       minAvailableMemoryRequiredInMb="0" 
       maxMemoryUsageInMb="0" 
       maxMemoryUsageCacheTimeInSeconds="0" 

--- a/Abot.Tests.Unit/App.config
+++ b/Abot.Tests.Unit/App.config
@@ -63,6 +63,7 @@
       isHttpRequestAutoRedirectsEnabled="true" 
       isHttpRequestAutomaticDecompressionEnabled="true" 
       isSendingCookiesEnabled="true" 
+      isSslCertificateValidationEnabled="false" 
       minAvailableMemoryRequiredInMb="25" 
       maxMemoryUsageInMb="26" 
       maxMemoryUsageCacheTimeInSeconds="27" 

--- a/Abot.Tests.Unit/Core/AbotConfigurationSectionHandlerTest.cs
+++ b/Abot.Tests.Unit/Core/AbotConfigurationSectionHandlerTest.cs
@@ -29,6 +29,7 @@ namespace Abot.Tests.Unit.Core
             Assert.AreEqual(true, _uut.CrawlBehavior.IsHttpRequestAutoRedirectsEnabled);
             Assert.AreEqual(true, _uut.CrawlBehavior.IsHttpRequestAutomaticDecompressionEnabled);
             Assert.AreEqual(true, _uut.CrawlBehavior.IsSendingCookiesEnabled);
+            Assert.AreEqual(false, _uut.CrawlBehavior.IsSslCertificateValidationEnabled);
             Assert.AreEqual(25, _uut.CrawlBehavior.MinAvailableMemoryRequiredInMb);
             Assert.AreEqual(26, _uut.CrawlBehavior.MaxMemoryUsageInMb);
             Assert.AreEqual(27, _uut.CrawlBehavior.MaxMemoryUsageCacheTimeInSeconds);
@@ -75,6 +76,7 @@ namespace Abot.Tests.Unit.Core
             Assert.AreEqual(true, _uut.CrawlBehavior.IsHttpRequestAutoRedirectsEnabled);
             Assert.AreEqual(true, _uut.CrawlBehavior.IsHttpRequestAutomaticDecompressionEnabled);
             Assert.AreEqual(true, _uut.CrawlBehavior.IsSendingCookiesEnabled);
+            Assert.AreEqual(false, _uut.CrawlBehavior.IsSslCertificateValidationEnabled);
             Assert.AreEqual(result.MinAvailableMemoryRequiredInMb, _uut.CrawlBehavior.MinAvailableMemoryRequiredInMb);
             Assert.AreEqual(result.MaxMemoryUsageInMb, _uut.CrawlBehavior.MaxMemoryUsageInMb);
             Assert.AreEqual(result.MaxMemoryUsageCacheTimeInSeconds, _uut.CrawlBehavior.MaxMemoryUsageCacheTimeInSeconds);
@@ -119,6 +121,7 @@ namespace Abot.Tests.Unit.Core
             Assert.AreEqual(pocoDefaults.RobotsDotTextUserAgentString, _uut.Politeness.RobotsDotTextUserAgentString);
             Assert.AreEqual(pocoDefaults.MaxPageSizeInBytes, _uut.CrawlBehavior.MaxPageSizeInBytes);
             Assert.AreEqual(pocoDefaults.HttpServicePointConnectionLimit, _uut.CrawlBehavior.HttpServicePointConnectionLimit);
+            Assert.AreEqual(pocoDefaults.IsSslCertificateValidationEnabled, _uut.CrawlBehavior.IsSslCertificateValidationEnabled);
             Assert.AreEqual(pocoDefaults.HttpRequestTimeoutInSeconds, _uut.CrawlBehavior.HttpRequestTimeoutInSeconds);
             Assert.AreEqual(pocoDefaults.HttpRequestMaxAutoRedirects, _uut.CrawlBehavior.HttpRequestMaxAutoRedirects);
             Assert.AreEqual(pocoDefaults.IsHttpRequestAutoRedirectsEnabled, _uut.CrawlBehavior.IsHttpRequestAutoRedirectsEnabled);

--- a/Abot.Tests.Unit/Poco/CrawlConfigurationTest.cs
+++ b/Abot.Tests.Unit/Poco/CrawlConfigurationTest.cs
@@ -35,6 +35,7 @@ namespace Abot.Tests.Unit.Poco
             Assert.AreEqual(true, unitUnderTest.IsHttpRequestAutoRedirectsEnabled);
             Assert.AreEqual(false, unitUnderTest.IsHttpRequestAutomaticDecompressionEnabled);
             Assert.AreEqual(false, unitUnderTest.IsSendingCookiesEnabled);
+            Assert.AreEqual(true, unitUnderTest.IsSslCertificateValidationEnabled);
             Assert.AreEqual(0, unitUnderTest.MaxMemoryUsageCacheTimeInSeconds);
             Assert.AreEqual(0, unitUnderTest.MaxMemoryUsageInMb);
             Assert.AreEqual(0, unitUnderTest.MinAvailableMemoryRequiredInMb);

--- a/Abot/Core/AbotConfigurationSectionHandler.cs
+++ b/Abot/Core/AbotConfigurationSectionHandler.cs
@@ -162,6 +162,12 @@ namespace Abot.Core
             get { return (bool)this["isExternalPageLinksCrawlingEnabled"]; }
         }
 
+        [ConfigurationProperty("isSslCertificateValidationEnabled", IsRequired = false, DefaultValue = true)]
+        public bool IsSslCertificateValidationEnabled
+        {
+            get { return (bool)this["isSslCertificateValidationEnabled"]; }
+        }
+
         [ConfigurationProperty("httpServicePointConnectionLimit", IsRequired = false, DefaultValue = 200)]
         public int HttpServicePointConnectionLimit
         {

--- a/Abot/Core/PageRequester.cs
+++ b/Abot/Core/PageRequester.cs
@@ -52,6 +52,10 @@ namespace Abot.Core
             if (_config.HttpServicePointConnectionLimit > 0)
                 ServicePointManager.DefaultConnectionLimit = _config.HttpServicePointConnectionLimit;
 
+            if (!_config.IsSslCertificateValidationEnabled)
+                ServicePointManager.ServerCertificateValidationCallback +=
+                    (sender, certificate, chain, sslPolicyErrors) => true;
+
             _extractor = contentExtractor ?? new WebContentExtractor();
         }
 

--- a/Abot/Poco/CrawlConfiguration.cs
+++ b/Abot/Poco/CrawlConfiguration.cs
@@ -20,6 +20,7 @@ namespace Abot.Poco
             MaxCrawlDepth = 100;
             HttpServicePointConnectionLimit = 200;
             HttpRequestTimeoutInSeconds = 15;
+            IsSslCertificateValidationEnabled = true;
         }
 
         #region crawlBehavior
@@ -122,6 +123,13 @@ namespace Abot.Poco
         /// Whether the cookies should be set and resent with every request
         /// </summary>
         public bool IsSendingCookiesEnabled { get; set; }
+
+        /// <summary>
+        /// Whether or not to validate the server SSL certificate. If true, the default validation will be made.
+        /// If false, the certificate validation is bypassed. This setting is useful to crawl sites with an
+        /// invalid or expired SSL certificate.
+        /// </summary>
+        public bool IsSslCertificateValidationEnabled { get; set; }
 
         /// <summary>
         /// Uses closest mulitple of 16 to the value set. If there is not at least this much memory available before starting a crawl, throws InsufficientMemoryException.

--- a/Abot/Poco/PageToCrawl.cs
+++ b/Abot/Poco/PageToCrawl.cs
@@ -36,6 +36,11 @@ namespace Abot.Poco
         public bool IsRetry { get; set; }
 
         /// <summary>
+        /// The time in seconds that the server sent to wait before retrying.
+        /// </summary>
+        public double? RetryAfter { get; set; }
+
+        /// <summary>
         /// The number of times the http request was be retried.
         /// </summary>
         public int RetryCount { get; set; }


### PR DESCRIPTION
I left the custom build of HtmlAgilityPack as it was.

Added parameter to bypass SSL certificate validation .
Added support for the Retry-After header which specifies the time to wait before retrying a request (see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)

PS. Sorry for the multiple commits/pull requests, I'm still on the git learning curve :)