### PR TITLE
Disposables, url fragment and tweaks

### DIFF
--- a/Abot/Core/CrawlDecisionMaker.cs
+++ b/Abot/Core/CrawlDecisionMaker.cs
@@ -135,7 +135,7 @@ namespace Abot.Core
             return new CrawlDecision { Allow = true };            
         }
 
-        public CrawlDecision ShouldRecrawlPage(CrawledPage crawledPage, CrawlContext crawlContext)
+        public virtual CrawlDecision ShouldRecrawlPage(CrawledPage crawledPage, CrawlContext crawlContext)
         {
             if (crawledPage == null)
                 return new CrawlDecision { Allow = false, Reason = "Null crawled page" };

--- a/Abot/Core/CsQueryHyperLinkParser.cs
+++ b/Abot/Core/CsQueryHyperLinkParser.cs
@@ -13,7 +13,6 @@ namespace Abot.Core
     public class CSQueryHyperlinkParser : HyperLinkParser
     {
         Func<string, string> _cleanURLFunc;
-        bool _isRespectMetaRobotsNoFollowEnabled;
         bool _isRespectAnchorRelNoFollowEnabled;
         
         public CSQueryHyperlinkParser()
@@ -23,7 +22,6 @@ namespace Abot.Core
         public CSQueryHyperlinkParser(bool isRespectMetaRobotsNoFollowEnabled, bool isRespectAnchorRelNoFollowEnabled, Func<string, string> cleanURLFunc = null)
             : base(isRespectMetaRobotsNoFollowEnabled)
         {
-            _isRespectMetaRobotsNoFollowEnabled = isRespectMetaRobotsNoFollowEnabled;
             _isRespectAnchorRelNoFollowEnabled = isRespectAnchorRelNoFollowEnabled;
             _cleanURLFunc = cleanURLFunc;
         }

--- a/Abot/Core/HapHyperLinkParser.cs
+++ b/Abot/Core/HapHyperLinkParser.cs
@@ -13,7 +13,6 @@ namespace Abot.Core
     public class HapHyperLinkParser : HyperLinkParser
     {
         Func<string, string> _cleanURLFunc;
-        bool _isRespectMetaRobotsNoFollowEnabled;
         bool _isRespectAnchorRelNoFollowEnabled;
 
         protected override string ParserType
@@ -26,10 +25,12 @@ namespace Abot.Core
         {
         }
 
-        public HapHyperLinkParser(bool isRespectMetaRobotsNoFollowEnabled, bool isRespectAnchorRelNoFollowEnabled, Func<string, string> cleanURLFunc = null)
-            :base(isRespectMetaRobotsNoFollowEnabled)
+        public HapHyperLinkParser(bool isRespectMetaRobotsNoFollowEnabled,
+                                  bool isRespectAnchorRelNoFollowEnabled,
+                                  Func<string, string> cleanURLFunc = null,
+                                  bool removeUrlFragment = true)
+            :base(isRespectMetaRobotsNoFollowEnabled, removeUrlFragment)
         {
-            _isRespectMetaRobotsNoFollowEnabled = isRespectMetaRobotsNoFollowEnabled;
             _isRespectAnchorRelNoFollowEnabled = isRespectAnchorRelNoFollowEnabled;
             _cleanURLFunc = cleanURLFunc;
         }

--- a/Abot/Core/PageRequester.cs
+++ b/Abot/Core/PageRequester.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Abot.Core
 {
-    public interface IPageRequester
+    public interface IPageRequester : IDisposable
     {
         /// <summary>
         /// Make an http web request to the url and download its content
@@ -34,7 +34,7 @@ namespace Abot.Core
 
         protected CrawlConfiguration _config;
         protected IWebContentExtractor _extractor;
-        protected CookieContainer container = new CookieContainer();
+        protected CookieContainer _cookieContainer = new CookieContainer();
 
         public PageRequester(CrawlConfiguration config)
             : this(config, null)
@@ -211,7 +211,7 @@ namespace Abot.Core
                 request.Timeout = _config.HttpRequestTimeoutInSeconds * 1000;
 
             if (_config.IsSendingCookiesEnabled)
-                request.CookieContainer = container;
+                request.CookieContainer = _cookieContainer;
 
             if (_config.IsAlwaysLogin)
             {
@@ -227,8 +227,18 @@ namespace Abot.Core
             if (response != null && _config.IsSendingCookiesEnabled)
             {
                 CookieCollection cookies = response.Cookies;
-                container.Add(cookies);
+                _cookieContainer.Add(cookies);
             }
+        }
+
+        public void Dispose()
+        {
+            if (_extractor != null)
+            {
+                _extractor.Dispose();
+            }
+            _cookieContainer = null;
+            _config = null;
         }
     }
 }

--- a/Abot/Core/Scheduler.cs
+++ b/Abot/Core/Scheduler.cs
@@ -7,7 +7,7 @@ namespace Abot.Core
     /// <summary>
     /// Handles managing the priority of what pages need to be crawled
     /// </summary>
-    public interface IScheduler
+    public interface IScheduler : IDisposable
     {
         /// <summary>
         /// Count of remaining items that are currently scheduled
@@ -92,6 +92,18 @@ namespace Abot.Core
         public void Clear()
         {
             _pagesToCrawlRepo.Clear();
+        }
+
+        public void Dispose()
+        {
+            if (_crawledUrlRepo != null)
+            {
+                _crawledUrlRepo.Dispose();
+            }
+            if (_pagesToCrawlRepo != null)
+            {
+                _pagesToCrawlRepo.Dispose();
+            }
         }
     }
 }

--- a/Abot/Core/WebContentExtractor.cs
+++ b/Abot/Core/WebContentExtractor.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 
 namespace Abot.Core
 {
-    public interface IWebContentExtractor
+    public interface IWebContentExtractor : IDisposable
     {
         PageContent GetContent(WebResponse response);
     }
@@ -124,6 +124,11 @@ namespace Abot.Core
             }
 
             return rawData;
+        }
+
+        public void Dispose()
+        {
+            // Nothing to do
         }
     }
 

--- a/Abot/Crawler/WebCrawler.cs
+++ b/Abot/Crawler/WebCrawler.cs
@@ -15,7 +15,7 @@ using Timer = System.Timers.Timer;
 
 namespace Abot.Crawler
 {
-    public interface IWebCrawler
+    public interface IWebCrawler : IDisposable
     {
         /// <summary>
         /// Synchronous event that is fired before a page is crawled.
@@ -1022,6 +1022,26 @@ namespace Abot.Crawler
             //TODO Cannot use RateLimiter since it currently cannot handle dynamic sleep times so using Thread.Sleep in the meantime
             if (milliToWait > 0)
                 Thread.Sleep(TimeSpan.FromMilliseconds(milliToWait));
+        }
+
+        public virtual void Dispose()
+        {
+            if (_threadManager != null)
+            {
+                _threadManager.Dispose();
+            }
+            if (_scheduler != null)
+            {
+                _scheduler.Dispose();
+            }
+            if (_pageRequester != null)
+            {
+                _pageRequester.Dispose();
+            }
+            if (_memoryManager != null)
+            {
+                _memoryManager.Dispose();
+            }
         }
     }
 }

--- a/Abot/Crawler/WebCrawler.cs
+++ b/Abot/Crawler/WebCrawler.cs
@@ -221,7 +221,7 @@ namespace Abot.Crawler
             if (uri == null)
                 throw new ArgumentNullException("uri");
 
-            _crawlContext.RootUri = uri;
+            _crawlContext.RootUri = _crawlContext.OriginalRootUri = uri;
 
             if (cancellationTokenSource != null)
                 _crawlContext.CancellationTokenSource = cancellationTokenSource;
@@ -670,7 +670,11 @@ namespace Abot.Crawler
                 //CrawledPage crawledPage = await CrawlThePage(pageToCrawl);
                 CrawledPage crawledPage = CrawlThePage(pageToCrawl);
 
-                if (IsRedirect(crawledPage))
+                // Validate the root uri in case of a redirection.
+                if (crawledPage.IsRoot)
+                    ValidateRootUriForRedirection(crawledPage);
+
+                if (IsRedirect(crawledPage) && !_crawlContext.CrawlConfiguration.IsHttpRequestAutoRedirectsEnabled)
                     ProcessRedirect(crawledPage);
                 
                 if (PageSizeIsAboveMax(crawledPage))
@@ -720,21 +724,12 @@ namespace Abot.Crawler
                 
             try
             {
-                var location = crawledPage.HttpWebResponse.Headers["Location"];
-                
-                Uri locationUri;
-                if (!Uri.TryCreate(location, UriKind.Absolute, out locationUri))
-                {
-                    var site = crawledPage.Uri.Scheme + "://" + crawledPage.Uri.Host;
-                    location = site + location;
-                }
-
-                var uri = new Uri(location);
+                var uri = GetRedirectUri(crawledPage);
 
                 PageToCrawl page = new PageToCrawl(uri);
                 page.ParentUri = crawledPage.ParentUri;
                 page.CrawlDepth = crawledPage.CrawlDepth;
-                page.IsInternal = _isInternalDecisionMaker(uri, _crawlContext.RootUri);
+                page.IsInternal = IsInternalUri(uri);
                 page.IsRoot = false;
                 page.RedirectedFrom = crawledPage;
                 page.RedirectPosition = crawledPage.RedirectPosition + 1;
@@ -751,14 +746,26 @@ namespace Abot.Crawler
             catch {}
         }
 
+        protected virtual bool IsInternalUri(Uri uri)
+        {
+            return  _isInternalDecisionMaker(uri, _crawlContext.RootUri) ||
+                _isInternalDecisionMaker(uri, _crawlContext.OriginalRootUri);
+        }
+
         protected virtual bool IsRedirect(CrawledPage crawledPage)
         {
-            return (!_crawlContext.CrawlConfiguration.IsHttpRequestAutoRedirectsEnabled &&
-                    crawledPage.HttpWebResponse != null &&
-                    ((int) crawledPage.HttpWebResponse.StatusCode >= 300 &&
-                     (int) crawledPage.HttpWebResponse.StatusCode <= 399));
+            bool isRedirect = false;
+            if (crawledPage.HttpWebResponse != null) {
+                isRedirect = (_crawlContext.CrawlConfiguration.IsHttpRequestAutoRedirectsEnabled &&
+                    crawledPage.HttpWebResponse.ResponseUri != null &&
+                    crawledPage.HttpWebResponse.ResponseUri.AbsoluteUri != crawledPage.Uri.AbsoluteUri) ||
+                    (!_crawlContext.CrawlConfiguration.IsHttpRequestAutoRedirectsEnabled &&
+                    (int) crawledPage.HttpWebResponse.StatusCode >= 300 &&
+                    (int) crawledPage.HttpWebResponse.StatusCode <= 399);
+            }
+            return isRedirect;
         }
-        
+
         protected virtual void ThrowIfCancellationRequested()
         {
             if (_crawlContext.CancellationTokenSource != null && _crawlContext.CancellationTokenSource.IsCancellationRequested)
@@ -927,7 +934,7 @@ namespace Abot.Crawler
                         PageToCrawl page = new PageToCrawl(uri);
                         page.ParentUri = crawledPage.Uri;
                         page.CrawlDepth = crawledPage.CrawlDepth + 1;
-                        page.IsInternal = _isInternalDecisionMaker(uri, _crawlContext.RootUri);
+                        page.IsInternal = IsInternalUri(uri);
                         page.IsRoot = false;
 
                         if (ShouldSchedulePageLink(page))
@@ -1022,6 +1029,53 @@ namespace Abot.Crawler
             //TODO Cannot use RateLimiter since it currently cannot handle dynamic sleep times so using Thread.Sleep in the meantime
             if (milliToWait > 0)
                 Thread.Sleep(TimeSpan.FromMilliseconds(milliToWait));
+        }
+
+        /// <summary>
+        /// Validate that the Root page was not redirected. If the root page is redirected, we assume that the root uri
+        /// should be changed to the uri where it was redirected.
+        /// </summary>
+        protected virtual void ValidateRootUriForRedirection(CrawledPage crawledRootPage)
+        {
+            if (!crawledRootPage.IsRoot) {
+                throw new ArgumentException("The crawled page must be the root page to be validated for redirection.");
+            }
+
+            if (IsRedirect(crawledRootPage)) {
+                _crawlContext.RootUri = GetRedirectUri(crawledRootPage);
+                _logger.InfoFormat("The root URI [{0}] was redirected to [{1}]. Pages from domains [{2}] and [{3}] will be considered internal.",
+                    _crawlContext.OriginalRootUri,
+                    _crawlContext.RootUri,
+                    _crawlContext.RootUri.Authority,
+                    _crawlContext.OriginalRootUri.Authority);
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the URI where the specified crawled page was redirected.
+        /// </summary>
+        /// <remarks>
+        /// If HTTP auto redirections is disabled, this value is stored in the 'Location' header of the response.
+        /// If auto redirections is enabled, this value is stored in the response's ResponseUri property.
+        /// </remarks>
+        protected virtual Uri GetRedirectUri(CrawledPage crawledPage)
+        {
+            Uri locationUri;
+            if (_crawlContext.CrawlConfiguration.IsHttpRequestAutoRedirectsEnabled) {
+                // For auto redirects, look for the response uri.
+                locationUri = crawledPage.HttpWebResponse.ResponseUri;
+            } else {
+                // For manual redirects, we need to look for the location header.
+                var location = crawledPage.HttpWebResponse.Headers["Location"];
+                
+                if (!Uri.TryCreate(location, UriKind.Absolute, out locationUri))
+                {
+                    var site = crawledPage.Uri.Scheme + "://" + crawledPage.Uri.Host;
+                    location = site + location;
+                    locationUri = new Uri(location);
+                }
+            }
+            return locationUri;
         }
 
         public virtual void Dispose()

--- a/Abot/Poco/CrawlContext.cs
+++ b/Abot/Poco/CrawlContext.cs
@@ -22,6 +22,12 @@ namespace Abot.Poco
         public Uri RootUri { get; set; }
 
         /// <summary>
+        /// The root of the crawl specified in the configuration. If the root URI was redirected to another URI,
+        /// it will be set in RootUri.
+        /// </summary>
+        public Uri OriginalRootUri { get; set; }
+
+        /// <summary>
         /// total number of pages that have been crawled
         /// </summary>
         public int CrawledCount = 0;


### PR DESCRIPTION
Changes:

1. Disposables
Added the IDisposable interface to PageRequester, Scheduler, WebContentExtractor and WebCrawler. This is useful when you have custom modules that needs to be disposed correctly!

2. Url fragment
Added  new parameter to the HyperlinkParser to remove or not the url fragment on each link ie everything after the "#" in the url. This is useful when a website keeps relevant data here, for instance single-page apps do this. I've kept the default behaviour of removing it!

3. WebContentExtractor
I've changed some methods in the WebContentExtractor to make them protected and overridable to be able to make a custom content extractor while still reusing the same GetCharsetFromBody and GetEncoding methods. GetCharsetFromBody now takes an input string because our custom WebContentExtractor downloads a string directly (no stream), and it does not affect the behaviour.

4. Root Uri validation
If you try to crawl with a root uri that gets redirected on the first call, nothing will be crawled. For instance, "http://dotnetperls.com/" redirects to "http://www.dotnetperls.com/". The redirection works but the redirected page is now considered external since it is on another authority than the starting address. To fix this we validate the root page, checking if the page was redirected and changing the RootUri if it was. Then, we consider links to "dotnetperls.com" and "www.dotnetperls.com" to be internal (since the website can have mixed links too).

All of this was thoroughly tested in our environment. If you have any questions just let me know!
