### PR TITLE
Check extracted links only once

### DIFF
--- a/Abot/Core/Scheduler.cs
+++ b/Abot/Core/Scheduler.cs
@@ -33,6 +33,18 @@ namespace Abot.Core
         /// Clear all currently scheduled pages
         /// </summary>
         void Clear();
+
+        /// <summary>
+        /// Add the Url to the list of crawled Url without scheduling it to be crawled.
+        /// </summary>
+        /// <param name="uri"></param>
+        void AddKnownUri(Uri uri);
+
+        /// <summary>
+        /// Returns whether or not the specified Uri was already scheduled to be crawled or simply added to the
+        /// list of known Uris.
+        /// </summary>
+        bool IsUriKnown(Uri uri);
     }
 
     [Serializable]
@@ -92,6 +104,16 @@ namespace Abot.Core
         public void Clear()
         {
             _pagesToCrawlRepo.Clear();
+        }
+
+        public void AddKnownUri(Uri uri)
+        {
+            _crawledUrlRepo.AddIfNew(uri);
+        }
+
+        public bool IsUriKnown(Uri uri)
+        {
+            return _crawledUrlRepo.Contains(uri);
         }
 
         public void Dispose()


### PR DESCRIPTION
We were crawling a website with links that appeared on pretty much all the pages (in the footer) that we were rejecting via the ShouldCrawlPage method of the decision maker.
This in turn was spamming a lot of OnPageDisallowed events because every time a link is found on a page, it was being checked by the decision maker in the "ShouldSchedulePageLink" method of the crawler, regardless of if it was already checked in the pass.

I added two little methods to the scheduler to check firstly if the links was never scheduled or found in another page.
The only drawback I can think of is that the crawled Urls repository can grow a little bigger now since we add all the found links, but there is a slight performance gain from not doing the same checks repeatedly, and looking for an uri in the concurrent dictionary is in O(1) complexity.