### PR TITLE
Temporary fix for Crawl() on Mono.

### DIFF
--- a/Abot/Poco/HttpWebResponseWrapper.cs
+++ b/Abot/Poco/HttpWebResponseWrapper.cs
@@ -38,7 +38,7 @@ namespace Abot.Poco
             this.ContentEncoding = response.ContentEncoding;
             this.Cookies = response.Cookies;
             this.IsFromCache = response.IsFromCache;
-            this.IsMutuallyAuthenticated = response.IsMutuallyAuthenticated;
+            //this.IsMutuallyAuthenticated = response.IsMutuallyAuthenticated;
             this.LastModified = GetLastModified(response);
             this.Method = response.Method;
             this.ProtocolVersion = response.ProtocolVersion;


### PR DESCRIPTION
On Mono, abot would not crawl due to an exception caused by HttpWebResponse.IsMutuallyAuthenticated, which seems to be not implemented.

This commit fixes #123