### PR TITLE
Enable automatic decompression on HttpWebRequest

### DIFF
--- a/Abot/Core/PageRequester.cs
+++ b/Abot/Core/PageRequester.cs
@@ -209,6 +209,7 @@ namespace Abot.Core
             request.AllowAutoRedirect = _config.IsHttpRequestAutoRedirectsEnabled;
             request.UserAgent = _config.UserAgentString;
             request.Accept = "*/*";
+            request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
             if (_config.HttpRequestMaxAutoRedirects > 0)
                 request.MaximumAutomaticRedirections = _config.HttpRequestMaxAutoRedirects;


### PR DESCRIPTION
Had issues with gzipped website (for example https://www.nianticlabs.com/) not being decompressed and therefore the content basically unreadable. Related to this SO answer: http://stackoverflow.com/a/2815876