### PR TITLE
Use HtmlDocument.MaxDepthLevel from latest HAP to replace local fix.

### DIFF
--- a/Abot.Tests.Unit/Abot.Tests.Unit.csproj
+++ b/Abot.Tests.Unit/Abot.Tests.Unit.csproj
@@ -66,7 +66,8 @@
       <HintPath>..\packages\FiddlerCore.4.4.8.4\lib\net40\FiddlerCore4.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack">
-      <HintPath>..\ExternalLib\HtmlAgilityPack.dll</HintPath>
+      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net40\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Ionic.Zip.Reduced">
       <HintPath>..\packages\DotNetZip.Reduced.1.9.1.8\lib\net20\Ionic.Zip.Reduced.dll</HintPath>

--- a/Abot.Tests.Unit/Poco/CrawledPageTest.cs
+++ b/Abot.Tests.Unit/Poco/CrawledPageTest.cs
@@ -64,6 +64,7 @@ namespace Abot.Tests.Unit.Poco
         [Test]
         public void HtmlDocument_ToManyNestedTagsInSource1_DoesNotCauseStackOverflowException()
         {
+            //FYI this test will not fail, it will just throw an uncatchable stackoverflowexception that will kill the process that runs this test
             CrawledPage unitUnderTest = new CrawledPage(new Uri("http://a.com/"))
             {
                 Content = new PageContent
@@ -73,14 +74,15 @@ namespace Abot.Tests.Unit.Poco
             };
 
             Assert.IsNotNull(unitUnderTest.HtmlDocument);
-            Assert.IsTrue(unitUnderTest.HtmlDocument.DocumentNode.InnerText.Length > 1);
+            Assert.AreEqual("", unitUnderTest.HtmlDocument.DocumentNode.InnerText);
         }
 
         [Test]
         public void HtmlDocument_ToManyNestedTagsInSource2_DoesNotCauseStackOverflowException()
         {
-            CrawledPage unitUnderTest = new CrawledPage(new Uri("http://a.com/")) 
-            { 
+            //FYI this test will not fail, it will just throw an uncatchable stackoverflowexception that will kill the process that runs this test
+            CrawledPage unitUnderTest = new CrawledPage(new Uri("http://a.com/"))
+            {
                 Content = new PageContent
                 {
                     Text = GetFileContent("HtmlAgilityPackStackOverflow2.html")
@@ -88,7 +90,7 @@ namespace Abot.Tests.Unit.Poco
             };
 
             Assert.IsNotNull(unitUnderTest.HtmlDocument);
-            Assert.IsTrue(unitUnderTest.HtmlDocument.DocumentNode.InnerText.Length > 1);
+            Assert.AreEqual("", unitUnderTest.HtmlDocument.DocumentNode.InnerText);
         }
 
         [Test]

--- a/Abot.Tests.Unit/Poco/CrawledPageTest.cs
+++ b/Abot.Tests.Unit/Poco/CrawledPageTest.cs
@@ -64,7 +64,6 @@ namespace Abot.Tests.Unit.Poco
         [Test]
         public void HtmlDocument_ToManyNestedTagsInSource1_DoesNotCauseStackOverflowException()
         {
-            //FYI this test will not fail, it will just throw an uncatchable stackoverflowexception that will kill the process that runs this test
             CrawledPage unitUnderTest = new CrawledPage(new Uri("http://a.com/"))
             {
                 Content = new PageContent
@@ -74,13 +73,12 @@ namespace Abot.Tests.Unit.Poco
             };
 
             Assert.IsNotNull(unitUnderTest.HtmlDocument);
-            Assert.AreEqual("", unitUnderTest.HtmlDocument.DocumentNode.InnerText);
+            Assert.IsTrue(unitUnderTest.HtmlDocument.DocumentNode.InnerText.Length > 1);
         }
 
         [Test]
         public void HtmlDocument_ToManyNestedTagsInSource2_DoesNotCauseStackOverflowException()
         {
-            //FYI this test will not fail, it will just throw an uncatchable stackoverflowexception that will kill the process that runs this test
             CrawledPage unitUnderTest = new CrawledPage(new Uri("http://a.com/")) 
             { 
                 Content = new PageContent
@@ -90,7 +88,7 @@ namespace Abot.Tests.Unit.Poco
             };
 
             Assert.IsNotNull(unitUnderTest.HtmlDocument);
-            Assert.AreEqual("", unitUnderTest.HtmlDocument.DocumentNode.InnerText);
+            Assert.IsTrue(unitUnderTest.HtmlDocument.DocumentNode.InnerText.Length > 1);
         }
 
         [Test]

--- a/Abot.Tests.Unit/packages.config
+++ b/Abot.Tests.Unit/packages.config
@@ -10,6 +10,7 @@
   <package id="elmah.corelibrary" version="1.2.2" targetFramework="net45" />
   <package id="ElmahFiddler" version="0.1.0" targetFramework="net45" />
   <package id="FiddlerCore" version="4.4.8.4" targetFramework="net45" />
+  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net452" />
   <package id="log4net" version="2.0.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />

--- a/Abot/Abot.csproj
+++ b/Abot/Abot.csproj
@@ -52,9 +52,9 @@
     <Reference Include="CsQuery">
       <HintPath>..\packages\CsQuery.1.3.4\lib\net40\CsQuery.dll</HintPath>
     </Reference>
-    <Reference Include="HtmlAgilityPack, Version=1.4.7.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ExternalLib\HtmlAgilityPack.dll</HintPath>
+    <Reference Include="HtmlAgilityPack, Version=1.4.9.5, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.4.9.5\lib\Net40\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.7\lib\net40-full\log4net.dll</HintPath>

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -146,7 +146,7 @@ namespace Abot.Poco
         private HtmlDocument InitializeHtmlAgilityPackDocument()
         {
             HtmlDocument hapDoc = new HtmlDocument();
-            HtmlDocument.MaxDepthLevel = 4000; //did not make this an externally configurable property since it is really an internal issue to hap
+            HtmlDocument.MaxDepthLevel = 100; //did not make this an externally configurable property since it is really an internal issue to hap
             try
             {
                 hapDoc.LoadHtml(Content.Text);

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -146,7 +146,7 @@ namespace Abot.Poco
         private HtmlDocument InitializeHtmlAgilityPackDocument()
         {
             HtmlDocument hapDoc = new HtmlDocument();
-            HtmlDocument.MaxDepthLevel = 100; //did not make this an externally configurable property since it is really an internal issue to hap
+            HtmlDocument.MaxDepthLevel = 10; //did not make this an externally configurable property since it is really an internal issue to hap
             try
             {
                 hapDoc.LoadHtml(Content.Text);

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -146,7 +146,7 @@ namespace Abot.Poco
         private HtmlDocument InitializeHtmlAgilityPackDocument()
         {
             HtmlDocument hapDoc = new HtmlDocument();
-            hapDoc.OptionFixNestedTags = true; //consider customizing this setting with config
+            HtmlDocument.MaxDepthLevel = 5000; //did not make this an externally configurable property since it is really an internal issue to hap
             try
             {
                 hapDoc.LoadHtml(Content.Text);

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -146,7 +146,7 @@ namespace Abot.Poco
         private HtmlDocument InitializeHtmlAgilityPackDocument()
         {
             HtmlDocument hapDoc = new HtmlDocument();
-            HtmlDocument.MaxDepthLevel = 5000; //did not make this an externally configurable property since it is really an internal issue to hap
+            HtmlDocument.MaxDepthLevel = 4000; //did not make this an externally configurable property since it is really an internal issue to hap
             try
             {
                 hapDoc.LoadHtml(Content.Text);

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -146,7 +146,7 @@ namespace Abot.Poco
         private HtmlDocument InitializeHtmlAgilityPackDocument()
         {
             HtmlDocument hapDoc = new HtmlDocument();
-            hapDoc.OptionMaxNestedChildNodes = 5000;//did not make this an externally configurable property since it is really an internal issue to hap
+            hapDoc.OptionFixNestedTags = true; //consider customizing this setting with config
             try
             {
                 hapDoc.LoadHtml(Content.Text);

--- a/Abot/packages.config
+++ b/Abot/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net40" />
   <package id="CsQuery" version="1.3.4" targetFramework="net40" />
+  <package id="HtmlAgilityPack" version="1.4.9.5" targetFramework="net40" />
   <package id="log4net" version="2.0.7" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />


### PR DESCRIPTION
HtmlDocument.MaxDepthLevel behaves the same as OptionMaxNestedChildNodes  and throws a catch-able exception rather than the problematic stackoverflowexception.