### PR TITLE
Changed visibility in some class fields

### DIFF
--- a/Abot/Core/DomainRateLimiter.cs
+++ b/Abot/Core/DomainRateLimiter.cs
@@ -36,7 +36,7 @@ namespace Abot.Core
     public class DomainRateLimiter : IDomainRateLimiter
     {
         static ILog _logger = LogManager.GetLogger("AbotLogger");
-        ConcurrentDictionary<string, IRateLimiter> _rateLimiterLookup = new ConcurrentDictionary<string, IRateLimiter>();
+        protected ConcurrentDictionary<string, IRateLimiter> _rateLimiterLookup = new ConcurrentDictionary<string, IRateLimiter>();
         long _defaultMinCrawlDelayInMillisecs;
 
         public DomainRateLimiter(long minCrawlDelayMillisecs)

--- a/Abot/Poco/CrawledPage.cs
+++ b/Abot/Poco/CrawledPage.cs
@@ -29,12 +29,12 @@ namespace Abot.Poco
         /// <summary>
         /// Lazy loaded Html Agility Pack (http://htmlagilitypack.codeplex.com/) document that can be used to retrieve/modify html elements on the crawled page.
         /// </summary>
-        public HtmlDocument HtmlDocument { get { return _htmlDocument.Value; } }
+        public virtual HtmlDocument HtmlDocument { get { return _htmlDocument.Value; } }
 
         /// <summary>
         /// Lazy loaded AngleSharp IHtmlDocument (https://github.com/AngleSharp/AngleSharp) that can be used to retrieve/modify html elements on the crawled page.
         /// </summary>
-        public IHtmlDocument AngleSharpHtmlDocument { get { return _angleSharpHtmlDocument.Value; } }
+        public virtual IHtmlDocument AngleSharpHtmlDocument { get { return _angleSharpHtmlDocument.Value; } }
 
         /// <summary>
         /// Web request sent to the server


### PR DESCRIPTION
- Added `protected` keyword to `_rateLimiterLookUp` dictionary in `DomainRateLimiter` class, because that dictionary needs to be visible in case the `GetRateLimiter` method is overridden by a subclass (see pull request https://github.com/sjdirect/abot/pull/194)
- Added `virtual` keyword to HTML document properties in `CrawledPage` to make it possible to override them in a custom subclass.