### PR TITLE
Change visibility of method GetRawData

### DIFF
--- a/Abot/Core/WebContentExtractor.cs
+++ b/Abot/Core/WebContentExtractor.cs
@@ -107,7 +107,7 @@ namespace Abot.Core
             return charset;
         }
 
-        private MemoryStream GetRawData(WebResponse webResponse)
+        protected virtual MemoryStream GetRawData(WebResponse webResponse)
         {
             MemoryStream rawData = new MemoryStream();
 


### PR DESCRIPTION
It is necessary in order to reuse this method in inherited classes.