### PR TITLE
Meta Tag Crawling

### DIFF
--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -77,13 +77,7 @@ namespace Abot2.Core
 
             //append http or https to the url
             if (!metaUrl.Contains(crawledPage.Uri.Scheme))
-            {
-                //if no host, add the crawled page host
-                if (string.IsNullOrEmpty(crawledPage.Uri.Host))
-                    metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
-                else
-                    metaUrl = $"{crawledPage.Uri.Scheme}://{metaUrl}";
-            }
+                metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
 
             return metaUrl;
         }

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -57,6 +57,32 @@ namespace Abot2.Core
             return baseTagValue.Value.Trim();
         }
 
+        protected override string GetMetaRedirectUrl(CrawledPage crawledPage)
+        {
+            var metaRedirect = crawledPage.AngleSharpHtmlDocument
+                .QuerySelectorAll("meta[http-equiv]")
+                .FirstOrDefault();
+
+            if (metaRedirect == null)
+                return "";
+
+            var content = metaRedirect.GetAttribute("content");
+
+            string metaUrl = "";
+            if (content?.ToLower().Contains("url=") == true)
+            {
+                int index = content.IndexOf("url=");
+                if (index > 0)
+                {
+                    metaUrl = content.Substring(index + 4);
+                    if (!metaUrl.Contains(crawledPage.Uri.Host))
+                        metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
+                }
+            }
+
+            return metaUrl;
+        }
+
         protected override string GetMetaRobotsValue(CrawledPage crawledPage)
         {
             var robotsMeta = crawledPage.AngleSharpHtmlDocument

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -60,13 +60,15 @@ namespace Abot2.Core
 
         protected override string GetMetaRedirectUrl(CrawledPage crawledPage)
         {
-            var body = crawledPage.Content.Text;
+            var metaMatch = crawledPage.AngleSharpHtmlDocument
+                .QuerySelectorAll("meta[http-equiv]")
+                .FirstOrDefault(d => d.GetAttribute("http-equiv").ToLowerInvariant() == "refresh");
 
-            bool metaMatches = Regex.IsMatch(body, @"http-equiv\W*?refresh\W*?""", RegexOptions.IgnoreCase);
-            if (!metaMatches)
-                return null;
+            if (metaMatch == null)
+                return "";
 
-            var contentMatches = Regex.Matches(body, @"<meta.*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
+            var content = metaMatch.GetAttribute("content");
+            var contentMatches = Regex.Matches(content, @".*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
 
             string metaUrl = null;
             if (contentMatches.Count == 0)

--- a/Abot2/Core/HyperLinkParser.cs
+++ b/Abot2/Core/HyperLinkParser.cs
@@ -44,9 +44,17 @@ namespace Abot2.Core
 
             var timer = Stopwatch.StartNew();
 
-            var links = GetUris(crawledPage, GetHrefValues(crawledPage))
-                .Select(hrv => new HyperLink(){ HrefValue = hrv})
-                .ToList();
+            List<HyperLink> links = new List<HyperLink>();
+
+            if (Config.FollowMetaRedirects)
+            {
+                string metaRedirectLink = GetMetaRedirectUrl(crawledPage);
+                if (!string.IsNullOrEmpty(metaRedirectLink))
+                    links.Add(new HyperLink() { HrefValue = new Uri(metaRedirectLink) });
+            }
+
+            links.AddRange(GetUris(crawledPage, GetHrefValues(crawledPage))
+                .Select(hrv => new HyperLink(){ HrefValue = hrv}));
             
             timer.Stop();
             Log.Debug("{0} parsed links from [{1}] in [{2}] milliseconds", ParserType, crawledPage.Uri, timer.ElapsedMilliseconds);
@@ -63,6 +71,8 @@ namespace Abot2.Core
         protected abstract string GetBaseHrefValue(CrawledPage crawledPage);
 
         protected abstract string GetMetaRobotsValue(CrawledPage crawledPage);
+
+        protected abstract string GetMetaRedirectUrl(CrawledPage crawledPage);
 
         #endregion
 

--- a/Abot2/Poco/CrawlConfiguration.cs
+++ b/Abot2/Poco/CrawlConfiguration.cs
@@ -19,6 +19,7 @@ namespace Abot2.Poco
             HttpServicePointConnectionLimit = 200;
             HttpRequestTimeoutInSeconds = 15;
             IsSslCertificateValidationEnabled = false;
+            FollowMetaRedirects = false;
         }
 
         #region crawlBehavior
@@ -222,6 +223,11 @@ namespace Abot2.Poco
         /// If zero, will use whatever the robots.txt crawl delay requests no matter how high the value is.
         /// </summary>
         public int MaxRobotsDotTextCrawlDelayInSeconds { get; set; }
+
+        /// <summary>
+        /// If true, will follow through on URLs found in meta tags.
+        /// </summary>
+        public bool FollowMetaRedirects { get; set; }
 
         #endregion
 


### PR DESCRIPTION
This feature adds functionality allowing the crawler to process links obtained from inside an HTML `<meta>` tag. The URL is then added to the list of links which can then be further processed.

I have created a new property in Abot2, `CrawlConfiguration.cs`, named `FollowMetaRedirects` defaulting to false.