### PR TITLE
Meta Tag Crawling

### DIFF
--- a/Abot2.Tests.Unit/Core/WebContentExtractorTest.cs
+++ b/Abot2.Tests.Unit/Core/WebContentExtractorTest.cs
@@ -243,7 +243,7 @@ namespace Abot2.Tests.Unit.Core
             var httpResponseMessage = new HttpResponseMessage()
             {
                 RequestMessage = new HttpRequestMessage(),
-                Content = new FakeHttpContent(_contentString + "<meta http-equiv = \"refresh\" content = \"0; url = test.html; charset = Shift_JIS\">")
+                Content = new FakeHttpContent(_contentString + "<meta HTTP-EQUIV = \"refresh\" CONTENT = \"0; URL = test.html; CHARSET = Shift_JIS\">")
             };
             using (var response = httpResponseMessage)
             {

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -77,13 +77,7 @@ namespace Abot2.Core
 
             //append http or https to the url
             if (!metaUrl.Contains(crawledPage.Uri.Scheme))
-            {
-                //if no host, add the crawled page host
-                if (string.IsNullOrEmpty(crawledPage.Uri.Host))
-                    metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
-                else
-                    metaUrl = $"{crawledPage.Uri.Scheme}://{metaUrl}";
-            }
+                metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
 
             return metaUrl;
         }

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -57,6 +57,32 @@ namespace Abot2.Core
             return baseTagValue.Value.Trim();
         }
 
+        protected override string GetMetaRedirectUrl(CrawledPage crawledPage)
+        {
+            var metaRedirect = crawledPage.AngleSharpHtmlDocument
+                .QuerySelectorAll("meta[http-equiv]")
+                .FirstOrDefault();
+
+            if (metaRedirect == null)
+                return "";
+
+            var content = metaRedirect.GetAttribute("content");
+
+            string metaUrl = "";
+            if (content?.ToLower().Contains("url=") == true)
+            {
+                int index = content.IndexOf("url=");
+                if (index > 0)
+                {
+                    metaUrl = content.Substring(index + 4);
+                    if (!metaUrl.Contains(crawledPage.Uri.Host))
+                        metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
+                }
+            }
+
+            return metaUrl;
+        }
+
         protected override string GetMetaRobotsValue(CrawledPage crawledPage)
         {
             var robotsMeta = crawledPage.AngleSharpHtmlDocument

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -58,31 +58,6 @@ namespace Abot2.Core
             return baseTagValue.Value.Trim();
         }
 
-        protected override string GetMetaRedirectUrl(CrawledPage crawledPage)
-        {
-            var metaMatch = crawledPage.AngleSharpHtmlDocument
-                .QuerySelectorAll("meta[http-equiv]")
-                .FirstOrDefault(d => d.GetAttribute("http-equiv").ToLowerInvariant() == "refresh");
-
-            if (metaMatch == null)
-                return "";
-
-            var content = metaMatch.GetAttribute("content");
-            var contentMatches = Regex.Matches(content, @".*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
-
-            string metaUrl = null;
-            if (contentMatches.Count == 0)
-                return null;
-            
-            if (contentMatches[0].Groups.Count > 1)
-                metaUrl = contentMatches[0].Groups[1].Value;
-
-            //append http or https to the url
-            if (!metaUrl.Contains(crawledPage.Uri.Scheme))
-                metaUrl = $"{crawledPage.Uri.Scheme}://{crawledPage.Uri.Host}/{metaUrl.TrimStart('/')}";
-
-            return metaUrl;
-        }
 
         protected override string GetMetaRobotsValue(CrawledPage crawledPage)
         {

--- a/Abot2/Core/AngleSharpHyperLinkParser.cs
+++ b/Abot2/Core/AngleSharpHyperLinkParser.cs
@@ -60,13 +60,15 @@ namespace Abot2.Core
 
         protected override string GetMetaRedirectUrl(CrawledPage crawledPage)
         {
-            var body = crawledPage.Content.Text;
+            var metaMatch = crawledPage.AngleSharpHtmlDocument
+                .QuerySelectorAll("meta[http-equiv]")
+                .FirstOrDefault(d => d.GetAttribute("http-equiv").ToLowerInvariant() == "refresh");
 
-            bool metaMatches = Regex.IsMatch(body, @"http-equiv\W*?refresh\W*?""", RegexOptions.IgnoreCase);
-            if (!metaMatches)
-                return null;
+            if (metaMatch == null)
+                return "";
 
-            var contentMatches = Regex.Matches(body, @"<meta.*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
+            var content = metaMatch.GetAttribute("content");
+            var contentMatches = Regex.Matches(content, @".*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
 
             string metaUrl = null;
             if (contentMatches.Count == 0)

--- a/Abot2/Core/HyperLinkParser.cs
+++ b/Abot2/Core/HyperLinkParser.cs
@@ -44,8 +44,6 @@ namespace Abot2.Core
 
             var timer = Stopwatch.StartNew();
 
-            var links = GetHyperLinks(crawledPage, GetRawHyperLinks(crawledPage));
-
             var links = new List<HyperLink>();
 
             if (Config.IsFollowMetaRedirectsEnabled)
@@ -54,8 +52,7 @@ namespace Abot2.Core
                     links.Add(new HyperLink() { HrefValue = new Uri(crawledPage.MetaRedirectURL) });
             }
 
-            links.AddRange(GetUris(crawledPage, GetHrefValues(crawledPage))
-                .Select(hrv => new HyperLink(){ HrefValue = hrv}));
+            links.AddRange(GetHyperLinks(crawledPage, GetRawHyperLinks(crawledPage)));
             
             timer.Stop();
             Log.Debug("{0} parsed links from [{1}] in [{2}] milliseconds", ParserType, crawledPage.Uri, timer.ElapsedMilliseconds);

--- a/Abot2/Core/HyperLinkParser.cs
+++ b/Abot2/Core/HyperLinkParser.cs
@@ -44,13 +44,12 @@ namespace Abot2.Core
 
             var timer = Stopwatch.StartNew();
 
-            List<HyperLink> links = new List<HyperLink>();
+            var links = new List<HyperLink>();
 
-            if (Config.FollowMetaRedirects)
+            if (Config.IsFollowMetaRedirectsEnabled)
             {
-                string metaRedirectLink = GetMetaRedirectUrl(crawledPage);
-                if (!string.IsNullOrEmpty(metaRedirectLink))
-                    links.Add(new HyperLink() { HrefValue = new Uri(metaRedirectLink) });
+                if (!string.IsNullOrEmpty(crawledPage.MetaRedirectURL))
+                    links.Add(new HyperLink() { HrefValue = new Uri(crawledPage.MetaRedirectURL) });
             }
 
             links.AddRange(GetUris(crawledPage, GetHrefValues(crawledPage))
@@ -71,8 +70,6 @@ namespace Abot2.Core
         protected abstract string GetBaseHrefValue(CrawledPage crawledPage);
 
         protected abstract string GetMetaRobotsValue(CrawledPage crawledPage);
-
-        protected abstract string GetMetaRedirectUrl(CrawledPage crawledPage);
 
         #endregion
 

--- a/Abot2/Core/HyperLinkParser.cs
+++ b/Abot2/Core/HyperLinkParser.cs
@@ -44,9 +44,17 @@ namespace Abot2.Core
 
             var timer = Stopwatch.StartNew();
 
-            var links = GetUris(crawledPage, GetHrefValues(crawledPage))
-                .Select(hrv => new HyperLink(){ HrefValue = hrv})
-                .ToList();
+            List<HyperLink> links = new List<HyperLink>();
+
+            if (Config.FollowMetaRedirects)
+            {
+                string metaRedirectLink = GetMetaRedirectUrl(crawledPage);
+                if (!string.IsNullOrEmpty(metaRedirectLink))
+                    links.Add(new HyperLink() { HrefValue = new Uri(metaRedirectLink) });
+            }
+
+            links.AddRange(GetUris(crawledPage, GetHrefValues(crawledPage))
+                .Select(hrv => new HyperLink(){ HrefValue = hrv}));
             
             timer.Stop();
             Log.Debug("{0} parsed links from [{1}] in [{2}] milliseconds", ParserType, crawledPage.Uri, timer.ElapsedMilliseconds);
@@ -63,6 +71,8 @@ namespace Abot2.Core
         protected abstract string GetBaseHrefValue(CrawledPage crawledPage);
 
         protected abstract string GetMetaRobotsValue(CrawledPage crawledPage);
+
+        protected abstract string GetMetaRedirectUrl(CrawledPage crawledPage);
 
         #endregion
 

--- a/Abot2/Core/PageRequester.cs
+++ b/Abot2/Core/PageRequester.cs
@@ -109,6 +109,8 @@ namespace Abot2.Core
                         {
                             crawledPage.DownloadContentStarted = DateTime.Now;
                             crawledPage.Content = await _contentExtractor.GetContentAsync(response).ConfigureAwait(false);
+                            if (_config.IsFollowMetaRedirectsEnabled)
+                                crawledPage.MetaRedirectURL = _contentExtractor.GetMetaRedirectUrl(crawledPage);
                             crawledPage.DownloadContentCompleted = DateTime.Now;
                         }
                         else

--- a/Abot2/Core/WebContentExtractor.cs
+++ b/Abot2/Core/WebContentExtractor.cs
@@ -50,7 +50,7 @@ namespace Abot2.Core
                 return "";
 
             var content = metaMatch.GetAttribute("content");
-            var contentMatches = Regex.Matches(content, @".*?url\s*=\s*([^""']+)", RegexOptions.IgnoreCase);
+            var contentMatches = Regex.Matches(content, @".*?url\s*=\s*([^""';]+)", RegexOptions.IgnoreCase);
 
             string metaUrl = null;
             if (contentMatches.Count == 0)

--- a/Abot2/Poco/CrawlConfiguration.cs
+++ b/Abot2/Poco/CrawlConfiguration.cs
@@ -19,7 +19,7 @@ namespace Abot2.Poco
             HttpServicePointConnectionLimit = 200;
             HttpRequestTimeoutInSeconds = 15;
             IsSslCertificateValidationEnabled = false;
-            FollowMetaRedirects = false;
+            IsFollowMetaRedirectsEnabled = false;
         }
 
         #region crawlBehavior
@@ -227,7 +227,7 @@ namespace Abot2.Poco
         /// <summary>
         /// If true, will follow through on URLs found in meta tags.
         /// </summary>
-        public bool FollowMetaRedirects { get; set; }
+        public bool IsFollowMetaRedirectsEnabled { get; set; }
 
         #endregion
 

--- a/Abot2/Poco/CrawlConfiguration.cs
+++ b/Abot2/Poco/CrawlConfiguration.cs
@@ -19,6 +19,7 @@ namespace Abot2.Poco
             HttpServicePointConnectionLimit = 200;
             HttpRequestTimeoutInSeconds = 15;
             IsSslCertificateValidationEnabled = false;
+            FollowMetaRedirects = false;
         }
 
         #region crawlBehavior
@@ -222,6 +223,11 @@ namespace Abot2.Poco
         /// If zero, will use whatever the robots.txt crawl delay requests no matter how high the value is.
         /// </summary>
         public int MaxRobotsDotTextCrawlDelayInSeconds { get; set; }
+
+        /// <summary>
+        /// If true, will follow through on URLs found in meta tags.
+        /// </summary>
+        public bool FollowMetaRedirects { get; set; }
 
         #endregion
 

--- a/Abot2/Poco/CrawledPage.cs
+++ b/Abot2/Poco/CrawledPage.cs
@@ -90,6 +90,11 @@ namespace Abot2.Poco
         public PageToCrawl RedirectedTo { get; set; }
 
         /// <summary>
+        /// The URL obtained from a meta redirect element
+        /// </summary>
+        public string MetaRedirectURL { get; set; }
+
+        /// <summary>
         /// Time it took from RequestStarted to RequestCompleted in milliseconds
         /// </summary>
         public double Elapsed => (RequestCompleted - RequestStarted).TotalMilliseconds;


### PR DESCRIPTION
This feature adds functionality allowing the crawler to process links obtained from inside an HTML `<meta>` tag. The URL is then added to the list of links which can then be further processed.

I have created a new property in Abot in `CrawlConfiguration.cs`, named `IsFollowMetaRedirectsEnabled`, defaulting to false.

Unit tests were also created testing success and fail cases to find a redirect URL:

- `GetContent_MetaUrl_RedirectDefinedInMetaTag_ReturnsCompletePageContentObject`
- `GetContent_MetaUrl_NoHttpEquivDefinedInMetaTag_ReturnsCompletePageContentObject`
- `GetContent_MetaUrl_NoMetaTag_ReturnsCompletePageContentObject`
- `GetContent_MetaUrl_BadlyFormattedMetaHttpEquiv_ReturnsCompletePageContentObject`

This is a follow up from a previous closed pull request, #215 with changes done as per feedback.

