### PR TITLE
Enable re-use of HttpClient instances

### DIFF
--- a/Abot2.Tests.Unit/Core/PageRequesterTest.cs
+++ b/Abot2.Tests.Unit/Core/PageRequesterTest.cs
@@ -253,6 +253,10 @@ namespace Abot2.Tests.Unit.Core
         [TestMethod]
         public async Task MakeRequestAsync_RealCall_ReturnsExpectedCrawledPageObject()
         {
+            // Clear re-use settings so the new "real" requester is
+            // used, not the mock.
+
+            PageRequester.DisposeReusedObjects();
             //Arrange
             var unitUnderTest = new PageRequester(
                 new CrawlConfiguration()
@@ -280,5 +284,5 @@ namespace Abot2.Tests.Unit.Core
 
             unitUnderTest.Dispose();
         }
-    }
+   }
 }

--- a/Abot2.Tests.Unit/Core/PageRequesterWithReuseTest.cs
+++ b/Abot2.Tests.Unit/Core/PageRequesterWithReuseTest.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Abot2.Core;
+using Abot2.Poco;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Abot2.Tests.Unit.Core
+{
+    [TestClass]
+    public class PageRequesterWithReuseTest
+    {
+        CrawlConfiguration _crawlConfig = new CrawlConfiguration()
+        {
+            ReUseHttpClientInstance = true
+        };
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            // Make sure our re-use settings are reset to known state
+            PageRequester.DisposeReusedObjects();
+        }
+
+        [TestMethod]
+        public async Task MakeRequestAsync_RealCall_ReturnsExpectedCrawledPageObject()
+        {
+            //Arrange
+            var unitUnderTest = new PageRequester(
+                new CrawlConfiguration()
+                {
+                    IsSslCertificateValidationEnabled = false,
+                    IsAlwaysLogin = true,
+                    IsHttpRequestAutomaticDecompressionEnabled = true,
+                    IsSendingCookiesEnabled = true,
+                    HttpProtocolVersion = HttpProtocolVersion.Version10
+                },
+                new WebContentExtractor());
+            var google = new Uri("https://google.com/");
+
+            //Act
+            var result = await unitUnderTest.MakeRequestAsync(google);
+
+            //Assert
+            Assert.IsNull(result.HttpRequestException);
+            Assert.AreSame(google, result.Uri);
+            Assert.IsNotNull(result.HttpRequestMessage);
+            Assert.IsNotNull(result.HttpResponseMessage);
+            Assert.IsNotNull(result.Content);
+
+            Assert.AreNotEqual("", result.Content.Text);
+
+            unitUnderTest.Dispose();
+        }
+
+        [TestMethod]
+        public async Task MakeRequestAsync_RealCall_ReUse_ReturnsExpectedCrawledPageObject()
+        {
+            //Arrange
+
+            // This test will fail if any previous tests used a cached mock http client, so we flush any cached instances
+            PageRequester.DisposeReusedObjects();
+
+            var unitUnderTest = new PageRequester(
+                new CrawlConfiguration()
+                {
+                    IsSslCertificateValidationEnabled = false,
+                    IsAlwaysLogin = true,
+                    IsHttpRequestAutomaticDecompressionEnabled = true,
+                    IsSendingCookiesEnabled = true,
+                    ReUseHttpClientInstance = true,
+                    HttpProtocolVersion = HttpProtocolVersion.Version10
+                },
+                new WebContentExtractor());
+            var google = new Uri("https://google.com/");
+
+            //Act
+            // ensure we have triggered use of the existing HTTPClient 
+            _ = await unitUnderTest.MakeRequestAsync(google);
+
+            // This request will re-use the previous HttpClient
+            var result = await unitUnderTest.MakeRequestAsync(google);
+
+            //Assert
+            Assert.IsNull(result.HttpRequestException);
+            Assert.AreSame(google, result.Uri);
+            Assert.IsNotNull(result.HttpRequestMessage);
+            Assert.IsNotNull(result.HttpResponseMessage);
+            Assert.IsNotNull(result.Content);
+
+            Assert.AreNotEqual("", result.Content.Text);
+
+            unitUnderTest.Dispose();
+        }
+    }
+}

--- a/Abot2/Abot2.csproj
+++ b/Abot2/Abot2.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0.8</Version>
+    <Version>2.0.71</Version>
     <PackageId>Abot</PackageId>
     <Authors>Steven Jones</Authors>
     <Company>SHARPDEV LLC</Company>

--- a/Abot2/Poco/CrawlConfiguration.cs
+++ b/Abot2/Poco/CrawlConfiguration.cs
@@ -17,6 +17,7 @@ namespace Abot2.Poco
             IsHttpRequestAutoRedirectsEnabled = true;
             MaxCrawlDepth = 100;
             HttpServicePointConnectionLimit = 200;
+            ReUseHttpClientInstance = false;
             HttpRequestTimeoutInSeconds = 15;
             IsSslCertificateValidationEnabled = false;
         }
@@ -97,6 +98,14 @@ namespace Abot2.Poco
         /// If zero, this setting has no effect.
         /// </summary>
         public int HttpServicePointConnectionLimit { get; set; }
+
+        /// <summary>
+        /// Directs classes that use HttpClient to re-use instances when possible rather than creating new HttpClient() instances.
+        /// If this flag is not set, you risk keeping a large number of inactive connections around. This is particularly required
+        /// for resource constrained situations like cloud hosted workers that limit connection counts.
+        /// See: https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation/
+        /// </summary>
+        public bool ReUseHttpClientInstance { get; set; }
 
         /// <summary>
         /// Gets or sets the time-out value in seconds for the System.Net.HttpWebRequest.GetResponse() and System.Net.HttpWebRequest.GetRequestStream() methods.


### PR DESCRIPTION
When scanning a large number of pages, the fact that PageRequester creates a large number of HttpClients can lead to many unused, but not closed connections. Even when disposed, the HttpClient instances can linger until they time out. In particular on Azure functions instances the connection limit was often triggered when using Abot

For more information see:
- https://docs.microsoft.com/en-us/azure/architecture/antipatterns/improper-instantiation/
- https://www.aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/

To address this I added simple management of a static, cached instance of the HttpClient used by all PageRequester instances
so it will re-use this HttpClient instance within PageRequester methods. I'm under a deadline so this is minimalist update but I did want to push it back as a contrib.

Adds a crawl config item to enable this re-use
Adds simple unit tests to exercise the re-use.

Please note: If you enable this setting you will likely need to call a new method PageRequester.DisposeReusedObjects() at the end of a scan session - which clears out/disposes any cached instance and resets itself to the default non-cached behavior. I did not add this to WebCrawler() or other associated classes since users may have multiple crawl sessions in-flight or other behavior I do not expect. If you implement your own custom requester from IPageRequester - you might also need to respond to this change. Also added a quick thread-safety mechanism for setting the cached instance in case they are being initialized within different threads.
