### PR TITLE
ExtractRedirectUri method does not work properly in Linux

### DIFF
--- a/Abot2/Crawler/WebCrawler.cs
+++ b/Abot2/Crawler/WebCrawler.cs
@@ -929,7 +929,7 @@ namespace Abot2.Crawler
                 var location = crawledPage.HttpResponseMessage?.Headers?.Location?.ToString();
 
                 // Check if the location is absolute. If not, create an absolute uri.
-                if (!Uri.TryCreate(location, UriKind.Absolute, out locationUri))
+                if (!Uri.TryCreate(location, UriKind.Absolute, out locationUri) || string.IsNullOrWhiteSpace(locationUri.Authority))
                 {
                     var baseUri = new Uri(crawledPage.Uri.GetLeftPart(UriPartial.Authority));
                     locationUri = new Uri(baseUri, location);


### PR DESCRIPTION
In dot net, on Linux (not in Windows), the `Uri.TryCreate` method with the `UriKind.Absolute` parameter returns true if the URL is relative.
